### PR TITLE
refactor: 하위 컴포넌트도 state 사용하도록 변경

### DIFF
--- a/App.js
+++ b/App.js
@@ -53,15 +53,11 @@ export default class App extends Component {
       addItem: addItem.bind(this),
     });
 
-    if (!this.itemsComponent) {
-      this.itemsComponent = new Items($items, {
-        filteredItems,
-        toggleItem: toggleItem.bind(this),
-        deleteItem: deleteItem.bind(this),
-      });
-    } else {
-      this.itemsComponent.$render();
-    }
+    new Items($items, {
+      filteredItems,
+      toggleItem: toggleItem.bind(this),
+      deleteItem: deleteItem.bind(this),
+    });
 
     new ItemFilter($itemFilter, {
       filterItem: filterItem.bind(this),

--- a/App.js
+++ b/App.js
@@ -53,11 +53,20 @@ export default class App extends Component {
       addItem: addItem.bind(this),
     });
 
-    new Items($items, {
-      filteredItems,
-      toggleItem: toggleItem.bind(this),
-      deleteItem: deleteItem.bind(this),
-    });
+    if (this.$components.items) {
+      this.$components.items.$target = $items;
+      this.$components.items.$props = {
+        filteredItems,
+        toggleItem: toggleItem.bind(this),
+        deleteItem: deleteItem.bind(this),
+      };
+    } else {
+      this.$components.items = new Items($items, {
+        filteredItems,
+        toggleItem: toggleItem.bind(this),
+        deleteItem: deleteItem.bind(this),
+      });
+    }
 
     new ItemFilter($itemFilter, {
       filterItem: filterItem.bind(this),

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -1,15 +1,23 @@
 export default class Component {
   $target;
-  $props;
   $state;
+  $components = {};
+
+  get $props() {
+    return this._props;
+  }
+
+  set $props(value) {
+    this._props = value;
+    this.render();
+    this.setEvent();
+  }
 
   constructor($target, $props) {
+    this.setup();
     this.$target = $target;
     this.$props = $props;
-    this.$render = this.render.bind(this);
-    this.setup();
-    this.setEvent();
-    this.render();
+    this.mounted();
   }
 
   setup() {}


### PR DESCRIPTION
props 값 변경시 rerender 되도록 수정
- rerender시, $target값이 돔이랑 연결이 끊기므로 다시 연결해주는 것이 필요!
- $target 값이 변경되었으므로 새로 이벤트를 달아줘야함 `this.setEvent();`